### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/pykwalify/core.py
+++ b/pykwalify/core.py
@@ -720,4 +720,4 @@ class Core(object):
         except KeyError as e:
             # Type not found in valid types mapping
             log.debug(e)
-            raise CoreError(u"Unknown type check: %s : %s : %s" % (path, value, t))
+            raise CoreError(u"Unknown type check: {0!s} : {1!s} : {2!s}".format(path, value, t))

--- a/tests/test_core_methods.py
+++ b/tests/test_core_methods.py
@@ -257,7 +257,7 @@ def test_validate_scalar_type():
     ]
 
     for data in data_matrix:
-        print("Testing data: '%s', '%s', '%s'" % data)
+        print("Testing data: '{0!s}', '{1!s}', '{2!s}'".format(*data))
         c = ec()
         c._validate_scalar_type(data[0], data[1], '')
         assert _remap_errors(c) == data[2]


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:pykwalify?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:pykwalify?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
